### PR TITLE
Fix duplicate tak_sender_loop

### DIFF
--- a/marshall_tak.py
+++ b/marshall_tak.py
@@ -556,22 +556,6 @@ def tak_sender_loop():
             interval = 10
         time.sleep(max(1, interval))
 
-def tak_sender_loop():
-    """Periodically send all non-stale tag data to the TAK server."""
-    global tak_client, tag_data, forwarding_config, tak_server_config
-    while True:
-        try:
-            tak_client.send_updates_for_changed_tags(tag_data, forwarding_config, tak_server_config)
-        except Exception as e:
-            print(f"Error in periodic TAK send: {e}")
-        interval = tak_server_config.get('send_interval', 10)
-        try:
-            interval = float(interval)
-        except (TypeError, ValueError):
-            interval = 10
-        time.sleep(max(1, interval))
-
-
 # ==== API endpoints for web controls ====
 
 @app.route('/api/tags')


### PR DESCRIPTION
## Summary
- remove the second `tak_sender_loop` definition in `marshall_tak.py`

## Testing
- `python3 -m py_compile marshall_tak.py`
- `flake8 marshall_tak.py` *(fails: style violations)*

------
https://chatgpt.com/codex/tasks/task_e_6864a9648a4c833380215596c31d4091