### PR TITLE
Refactor TAK forwarding worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,12 +196,9 @@ See `GIT_SETUP.md` for detailed Git workflow and best practices.
 - `marshall_tak.py` - Main application with serial port configuration
 - `forwarding_config.json` - TAK forwarding settings
 - `tak_server_config.json` - TAK server connection settings. Includes
-
-
-  `send_interval` which throttles how quickly updates are forwarded to the
-  TAK server. The value can be adjusted on the web dashboard via a drop-down
-  menu (2–60 seconds). Parsed tag updates are queued and sent in order using
-  this interval as the delay between messages.
+  `send_interval` which controls how often all valid tags are forwarded to the
+  TAK server as a batch. The value can be adjusted on the web dashboard
+  (2–60 seconds).
 
 
 - `templates.json` - Saved configuration templates
@@ -221,7 +218,7 @@ The application creates comprehensive logs in the `comprehensive_logs/` director
 - `GET /api/data` - Returns packet history and statistics
 - `POST /api/tak_server` - Configure TAK server settings (IP, port, and
 
-  `send_interval`). The interval controls how often tag data is forwarded.
+  `send_interval`). The interval controls how often all valid tags are forwarded.
 
 - `POST /api/forward_all` - Enable/disable forwarding for all tags
 - `POST /api/tag/{id}/forward` - Configure individual tag forwarding


### PR DESCRIPTION
## Summary
- clean up unused send queue
- periodically forward snapshots of current tag data
- compute staleness using `get_tag_staleness`
- document that `send_interval` controls batch forwarding frequency

## Testing
- `python3 -m py_compile marshall_tak.py`
- `python3 - <<'PY'
import marshall_tak, time
marshall_tak.tak_server_config['ip']='127.0.0.1'
marshall_tak.tak_server_config['send_interval']=0.5
marshall_tak.forwarding_config['forward_all']=True
marshall_tak.tag_data={1:{'tag_id':1,'latitude':10,'longitude':20,'altitude':100,'battery_voltage':3.7,'temperature':25,'timestamp_epoch':time.time(),'is_fresh':True,'bad_gps':False}}
client=marshall_tak.AtosTAKClient(); marshall_tak.tak_client=client
for _ in range(3):
    snapshot={tid:data.copy() for tid,data in marshall_tak.tag_data.items()}
    client.send_updates_for_changed_tags(snapshot, marshall_tak.forwarding_config, marshall_tak.tak_server_config)
    time.sleep(marshall_tak.tak_server_config['send_interval'])
PY`

------
https://chatgpt.com/codex/tasks/task_e_6865045839a88333bd3b34f4d3e64b0d